### PR TITLE
fix devDeps added to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,21 +9,18 @@
   "dependencies": {
     "gettemporaryfilepath": "=0.0.1",
     "memoizeasync": "=0.8.0",
-    "mocha": "2.4.5",
     "pngcrush-bin": "^3.0.0",
-    "sinon": "1.17.3",
-    "unexpected": "10.11.1",
-    "unexpected-sinon": "10.2.0",
-    "unexpected-stream": "2.0.3",
     "which": "=1.1.2"
   },
   "devDependencies": {
     "coveralls": "2.11.2",
     "istanbul": "0.3.15",
     "jshint": "2.8.0",
-    "mocha": "2.2.5",
-    "unexpected": "9.4.0",
-    "unexpected-stream": "1.2.0"
+    "mocha": "2.4.5",
+    "sinon": "1.17.3",
+    "unexpected": "10.11.1",
+    "unexpected-sinon": "10.2.0",
+    "unexpected-stream": "2.0.3"
   },
   "scripts": {
     "lint": "jshint .",


### PR DESCRIPTION
A `--save` was accidentally used instead of a `--save-dev` when upgrading unexpected recently. This moves it back to deps. 
